### PR TITLE
1. When change the Org on check, cash or manual Payment it need to cl…

### DIFF
--- a/ViennaAdvantage/Areas/VA009/Controllers/PaymentController.cs
+++ b/ViennaAdvantage/Areas/VA009/Controllers/PaymentController.cs
@@ -96,21 +96,39 @@ namespace VA009.Controllers
             return Json(JsonConvert.SerializeObject(_Paydata), JsonRequestBehavior.AllowGet);
         }
 
-        public JsonResult GetConvertedAmt(string PaymentData, int BankAccount, int CurrencyType)
+        /// <summary>
+        /// Get Updated Converted Amount with Payment Data
+        /// </summary>
+        /// <param name="PaymentData">Payment Data</param>
+        /// <param name="BankAccount">C_BankAccount_ID</param>
+        /// <param name="CurrencyType">C_ConversionType_ID</param>
+        /// <param name="dateAcct">Account Date</param>
+        /// <param name="_org_Id">AD_Org_ID</param>
+        /// <returns>returns Payment Data to bind on grid</returns>
+        public JsonResult GetConvertedAmt(string PaymentData, int BankAccount, int CurrencyType, DateTime? dateAcct, int _org_Id)
         {
             GeneratePaymt[] arr = JsonConvert.DeserializeObject<GeneratePaymt[]>(PaymentData);
             Ctx ctx = Session["ctx"] as Ctx;
             PaymentModel _payMdl = new PaymentModel();
-            List<PaymentData> _Paydata = _payMdl.ConvertedAmt(ctx, arr, BankAccount, CurrencyType);
+            List<PaymentData> _Paydata = _payMdl.ConvertedAmt(ctx, arr, BankAccount, CurrencyType, dateAcct, _org_Id);
             return Json(JsonConvert.SerializeObject(_Paydata), JsonRequestBehavior.AllowGet);
         }
 
-        public JsonResult GetCashJournalConvertedAmt(string PaymentData, int CurrencyCashBook, int CurrencyType)
+        /// <summary>
+        /// Get CashLine Data in JSON format
+        /// </summary>
+        /// <param name="PaymentData">Payment Data</param>
+        /// <param name="CurrencyCashBook">CashBook C_Currency_ID</param>
+        /// <param name="CurrencyType">C_ConversionType_ID</param>
+        /// <param name="dateAcct">DateAcct</param>
+        /// <param name="_org_Id">AD_Org_ID</param>
+        /// <returns>returns JSON result</returns>
+        public JsonResult GetCashJournalConvertedAmt(string PaymentData, int CurrencyCashBook, int CurrencyType, DateTime? dateAcct, int _org_Id)
         {
             GeneratePaymt[] arr = JsonConvert.DeserializeObject<GeneratePaymt[]>(PaymentData);
             Ctx ctx = Session["ctx"] as Ctx;
             PaymentModel _payMdl = new PaymentModel();
-            List<PaymentData> Paydata = _payMdl.CashBookConvertedAmt(ctx, arr, CurrencyCashBook, CurrencyType);
+            List<PaymentData> Paydata = _payMdl.CashBookConvertedAmt(ctx, arr, CurrencyCashBook, CurrencyType, dateAcct, _org_Id);
             return Json(JsonConvert.SerializeObject(Paydata), JsonRequestBehavior.AllowGet);
         }
 

--- a/ViennaAdvantage/Areas/VA009/Models/PaymentModel.cs
+++ b/ViennaAdvantage/Areas/VA009/Models/PaymentModel.cs
@@ -3061,11 +3061,11 @@ namespace VA009.Models
                         {
                             if (PaymentData[i].DueAmt < 0)
                             {
-                                _payData.convertedAmt = PaymentData[i].DueAmt;
+                                _payData.convertedAmt = -1 * PaymentData[i].DueAmt;//On UI should get amount in positive sign
                             }
                             else
                             {
-                                _payData.convertedAmt = -1 * PaymentData[i].DueAmt; // -1 Because during payble dont show negative amount on UI
+                                _payData.convertedAmt = PaymentData[i].DueAmt; // -1 Because during payble dont show negative amount on UI
                             }
                         }
                         else
@@ -3278,7 +3278,7 @@ namespace VA009.Models
                             //modified according to user selected AcctDate and BankAccount Org_ID
                             //convrtedamt = -1 * MConversionRate.Convert(ctx, -1 * PaymentData[i].DueAmt, PaymentData[i].C_Currency_ID, CurrencyCashBook, DateTime.Now, CurrencyType, PaymentData[i].AD_Client_ID, PaymentData[i].AD_Org_ID);
                             convrtedamt = MConversionRate.Convert(ctx, PaymentData[i].DueAmt, PaymentData[i].C_Currency_ID, CurrencyCashBook, dateAcct, CurrencyType, PaymentData[i].AD_Client_ID, org_ID);
-                            convrtedamt = convrtedamt < 0 ? convrtedamt : -1 * convrtedamt;
+                            convrtedamt = convrtedamt >= 0 ? convrtedamt : -1 * convrtedamt; //on UI will get amount in positive sign
                         }
                         else
                         {
@@ -3296,12 +3296,12 @@ namespace VA009.Models
                     {
                         if (PaymentData[i].DueAmt < 0)
                         {
-                            _payData.DueAmt = PaymentData[i].DueAmt;
+                            _payData.DueAmt = -1 * PaymentData[i].DueAmt; //on UI will get amount in positive sign
                         }
                         else
                         {
-                            //missing sign added
-                            _payData.DueAmt = -1 * PaymentData[i].DueAmt; //-1 Because during payble dont show negative amount on UI
+                            //on UI will get amount in positive sign
+                            _payData.DueAmt = PaymentData[i].DueAmt; //-1 Because during payble dont show negative amount on UI
                         }
                     }
                     else

--- a/ViennaAdvantageSvc/Common/DBFuncCollection.cs
+++ b/ViennaAdvantageSvc/Common/DBFuncCollection.cs
@@ -12,6 +12,17 @@ namespace ViennaAdvantage.Common
 {
     public static class DBFuncCollection
     {
+        /// <summary>
+        /// Get the Query in string format to get Invoice and Order Schedules
+        /// </summary>
+        /// <param name="ctx">Currenct Context</param>
+        /// <param name="whereQry">WHERE CLAUSE query</param>
+        /// <param name="SearchText">Search Text</param>
+        /// <param name="WhrDueDate">Due Date</param>
+        /// <param name="TransType">Transaction Type</param>
+        /// <param name="FromDate">From Date</param>
+        /// <param name="ToDate">To Date</param>
+        /// <returns>returns string value query to get Invoice and Order Schedules</returns>
         public static string GetPaymentDataSql(Ctx ctx, string whereQry, string SearchText, string WhrDueDate, string TransType, string FromDate, string ToDate)
         {
             StringBuilder sql = new StringBuilder();
@@ -30,7 +41,8 @@ namespace ViennaAdvantage.Common
             {
                 TransTypes = new int[0];
             }
-            int conversionType_ID = ctx.GetContextAsInt("#C_ConversionType_ID");
+            //when load the Schedules should get Converted Amount based on Schedule ConversionType not the default ConversionType
+            //int conversionType_ID = ctx.GetContextAsInt("#C_ConversionType_ID");
 
             if (DB.IsOracle())
             {
@@ -48,8 +60,8 @@ namespace ViennaAdvantage.Common
                          CASE WHEN (cd.DOCBASETYPE IN ('ARI','APC')) THEN ROUND(cs.DUEAMT,NVL(CY.StdPrecision,2)) WHEN (cd.DOCBASETYPE IN ('API','ARC'))     
                          THEN ROUND(cs.DUEAMT,NVL(CY.StdPrecision,2)) * 1  END AS DueAmt,
                          cs.VA009_OpenAmnt, rsf.name as VA009_ExecutionStatus,  cs.ad_org_id,  cs.ad_client_id ,
-                         inv.C_Currency_ID,  cc.ISO_CODE, ac.c_currency_id as basecurrency,  CURRENCYRATE(cc.C_CURRENCY_ID,cy.C_CURRENCY_ID,TRUNC(sysdate)," + conversionType_ID
-                             + @",inv.AD_Client_ID,inv.AD_ORG_ID) as multiplyrate, cy.ISO_CODE as basecurrencycode,inv.GrandTotal, (to_date(TO_CHAR(TRUNC(cs.VA009_PlannedDueDate)),'dd/mm/yyyy')
+                         inv.C_Currency_ID,  cc.ISO_CODE, ac.c_currency_id as basecurrency,  CURRENCYRATE(cc.C_CURRENCY_ID,cy.C_CURRENCY_ID, cs.DueDate, inv.C_ConversionType_ID,
+                         inv.AD_Client_ID,inv.AD_ORG_ID) as multiplyrate, cy.ISO_CODE as basecurrencycode,inv.GrandTotal, (to_date(TO_CHAR(TRUNC(cs.VA009_PlannedDueDate)),'dd/mm/yyyy')
                         -to_date(TO_CHAR(TRUNC(sysdate)),'dd/mm/yyyy')) as Due_Date_Diff,cs.duedate, 'Invoice' AS VA009_TransactionType, cs.IsHoldPayment FROM 
                          C_InvoicePaySchedule cs INNER JOIN VA009_PaymentMethod pm ON pm.VA009_PaymentMethod_ID=cs.VA009_PaymentMethod_ID INNER JOIN C_Doctype 
                          cd ON cs.C_Doctype_ID=cd.C_Doctype_ID INNER JOIN ad_ref_list rsf ON rsf.value= cs.VA009_ExecutionStatus INNER JOIN ad_reference re ON 
@@ -124,7 +136,7 @@ namespace ViennaAdvantage.Common
                         CASE  WHEN (cd.DOCBASETYPE IN ('SOO','APC')) THEN ROUND(cs.DUEAMT,NVL(CY.StdPrecision,2)) WHEN (cd.DOCBASETYPE IN ('POO','ARC')) 
                         THEN ROUND(cs.DUEAMT,NVL(CY.StdPrecision,2)) * 1 END AS DueAmt,
                         cs.VA009_OpenAmnt, rsf.name AS VA009_ExecutionStatus, cs.ad_org_id, cs.ad_client_id, inv.C_Currency_ID, cc.ISO_CODE, ac.c_currency_id  AS basecurrency,
-                        CURRENCYRATE(cc.C_CURRENCY_ID,cy.C_CURRENCY_ID,TRUNC(sysdate)," + conversionType_ID + @",inv.AD_Client_ID,inv.AD_ORG_ID) AS multiplyrate,  cy.ISO_CODE AS basecurrencycode,
+                        CURRENCYRATE(cc.C_CURRENCY_ID,cy.C_CURRENCY_ID,cs.DueDate, inv.C_ConversionType_ID,inv.AD_Client_ID,inv.AD_ORG_ID) AS multiplyrate,  cy.ISO_CODE AS basecurrencycode,
                         inv.GrandTotal, (to_date(TO_CHAR(TRUNC(cs.VA009_PlannedDueDate)),'dd/mm/yyyy') -to_date(TO_CHAR(TRUNC(sysdate)),'dd/mm/yyyy')) AS Due_Date_Diff,
                         cs.duedate, 'Order' AS VA009_TransactionType, 'N' AS IsHoldPayment
                         FROM VA009_OrderPaySchedule cs INNER JOIN VA009_PaymentMethod pm   ON pm.VA009_PaymentMethod_ID=cs.VA009_PaymentMethod_ID
@@ -198,8 +210,8 @@ namespace ViennaAdvantage.Common
                          CASE WHEN (cd.DOCBASETYPE IN ('ARI','APC')) THEN ROUND(cs.DUEAMT,NVL(CY.StdPrecision,2)) WHEN (cd.DOCBASETYPE IN ('API','ARC'))     
                          THEN ROUND(cs.DUEAMT,NVL(CY.StdPrecision,2)) * 1  END AS DueAmt,
                          cs.VA009_OpenAmnt, rsf.name as VA009_ExecutionStatus,  cs.ad_org_id,  cs.ad_client_id ,
-                         inv.C_Currency_ID,  cc.ISO_CODE, ac.c_currency_id as basecurrency,  CURRENCYRATE(cc.C_CURRENCY_ID,cy.C_CURRENCY_ID,TRUNC(sysdate)," + conversionType_ID
-                             + @",inv.AD_Client_ID,inv.AD_ORG_ID) as multiplyrate, cy.ISO_CODE as basecurrencycode,inv.GrandTotal, 
+                         inv.C_Currency_ID,  cc.ISO_CODE, ac.c_currency_id as basecurrency,  CURRENCYRATE(cc.C_CURRENCY_ID,cy.C_CURRENCY_ID, cs.DueDate, inv.C_ConversionType_ID,
+                         inv.AD_Client_ID,inv.AD_ORG_ID) as multiplyrate, cy.ISO_CODE as basecurrencycode,inv.GrandTotal, 
                          DATE_PART('day', (to_date(TO_CHAR(TRUNC(cs.VA009_PlannedDueDate),'dd/mm/yyyy'),'dd/mm/yyyy')-to_date(TO_CHAR(TRUNC(sysdate),'dd/mm/yyyy'),'dd/mm/yyyy'))) 
                          as Due_Date_Diff,cs.duedate, 'Invoice' AS VA009_TransactionType, cs.IsHoldPayment FROM 
                          C_InvoicePaySchedule cs INNER JOIN VA009_PaymentMethod pm ON pm.VA009_PaymentMethod_ID=cs.VA009_PaymentMethod_ID INNER JOIN C_Doctype 
@@ -275,7 +287,7 @@ namespace ViennaAdvantage.Common
                         CASE  WHEN (cd.DOCBASETYPE IN ('SOO','APC')) THEN ROUND(cs.DUEAMT,NVL(CY.StdPrecision,2)) WHEN (cd.DOCBASETYPE IN ('POO','ARC')) 
                         THEN ROUND(cs.DUEAMT,NVL(CY.StdPrecision,2)) * 1 END AS DueAmt,
                         cs.VA009_OpenAmnt, rsf.name AS VA009_ExecutionStatus, cs.ad_org_id, cs.ad_client_id, inv.C_Currency_ID, cc.ISO_CODE, ac.c_currency_id  AS basecurrency,
-                        CURRENCYRATE(cc.C_CURRENCY_ID,cy.C_CURRENCY_ID,TRUNC(sysdate)," + conversionType_ID + @",inv.AD_Client_ID,inv.AD_ORG_ID) AS multiplyrate,  cy.ISO_CODE AS basecurrencycode,
+                        CURRENCYRATE(cc.C_CURRENCY_ID,cy.C_CURRENCY_ID, cs.DueDate, inv.C_ConversionType_ID,inv.AD_Client_ID,inv.AD_ORG_ID) AS multiplyrate,  cy.ISO_CODE AS basecurrencycode,
                         inv.GrandTotal, DATE_PART('day', (to_date(TO_CHAR(TRUNC(cs.VA009_PlannedDueDate),'dd/mm/yyyy'),'dd/mm/yyyy') -to_date(TO_CHAR(TRUNC(sysdate),'dd/mm/yyyy'),'dd/mm/yyyy'))) AS Due_Date_Diff,
                         cs.duedate, 'Order' AS VA009_TransactionType, 'N' AS IsHoldPayment
                         FROM VA009_OrderPaySchedule cs INNER JOIN VA009_PaymentMethod pm   ON pm.VA009_PaymentMethod_ID=cs.VA009_PaymentMethod_ID


### PR DESCRIPTION
1. When change the Org on check, cash or manual Payment it need to clear the Bank and Bank Account fields.

2. when change the DateAcct on Check, Cash buttons pop-up window for both Payables and receivables it should get the Converted Amount according to that.
3. When do the split the schedule and change the AccDate it should not be Invalid if user not selected Date.
4. Converted Amount on Payment Form Grid should show based on Schedule Due Date not the System Date.