### PR TITLE
Space required between the Message and AccountNo when Update checkNo …

### DIFF
--- a/ViennaAdvantageSvc/Process/VA009_Generate_Payment.cs
+++ b/ViennaAdvantageSvc/Process/VA009_Generate_Payment.cs
@@ -733,7 +733,8 @@ namespace ViennaAdvantage.Process
                                                 Get_TrxName().Rollback();
                                                 msg = Msg.GetMsg(GetCtx(), checkMsg);
                                                 MBankAccount ba = new MBankAccount(GetCtx(), Util.GetValueOfInt(ds.Tables[0].Rows[i]["c_bankaccount_id"]), Get_TrxName());
-                                                return msg + ":" + ba.GetAccountNo();
+                                                //Want space between the Message and AccountNo
+                                                return msg + " : " + ba.GetAccountNo();
                                             }
                                         }
                                         else if (tenderType == "T")    // Direct Deposit
@@ -1017,7 +1018,8 @@ namespace ViennaAdvantage.Process
                                             Get_TrxName().Rollback();
                                             msg = Msg.GetMsg(GetCtx(), checkMsg);
                                             MBankAccount ba = new MBankAccount(GetCtx(), Util.GetValueOfInt(ds.Tables[0].Rows[i]["c_bankaccount_id"]), Get_TrxName());
-                                            return msg + ":" + ba.GetAccountNo();
+                                            //Want space between the Message and AccountNo
+                                            return msg + " : " + ba.GetAccountNo();
                                         }
                                     }
                                     else if (tenderType == "T")    // Direct Deposit


### PR DESCRIPTION
Space required between the Message and AccountNo when Update checkNo on  Payment When click on Generate Payments in Payment Schedule Batch window.